### PR TITLE
bump rust toolchain and relax dependencies to fixed minor version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,15 +37,15 @@ jobs:
       - name: Setup rust
         run: |
           rustup set profile minimal
-          rustup toolchain install nightly-2023-06-25
-          rustup default nightly-2023-06-25
+          rustup toolchain install nightly-2023-08-21
+          rustup default nightly-2023-08-21
 
       - name: Build tests and copy binaries to a separate dir
         shell: bash
         run: |
           mkdir artifacts
           CARGO_TARGET_DIR=./build \
-          cargo +nightly-2023-06-25 test --no-run --release --message-format=json -q \
+          cargo +nightly-2023-08-21 test --no-run --release --message-format=json -q \
           | jq -r 'select(.executable != null) | .executable' \
           | while read binary; do
             cp "$binary" artifacts/

--- a/criterion-cuda/Cargo.toml
+++ b/criterion-cuda/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-criterion = "0.4.0"
+criterion = "0.4"
 cudart = { path = "../cudart" }

--- a/cudart-sys/Cargo.toml
+++ b/cudart-sys/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [build-dependencies]
-bindgen = "0.69.4"
-serde_json = "1.0.113"
+bindgen = "0.69"
+serde_json = "1.0"

--- a/cudart/Cargo.toml
+++ b/cudart/Cargo.toml
@@ -6,8 +6,8 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 cudart-sys = { path = "../cudart-sys" }
-bitflags = "2.4.2"
-paste = "1.0.14"
+bitflags = "2.4"
+paste = "1.0"
 
 [dev-dependencies]
-serial_test = "3.0.0"
+serial_test = "3.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-06-25"
+channel = "nightly-2023-08-21"


### PR DESCRIPTION
# What ❔

This PR bumps the rust toolchain version tonightly-2023-08-21 and relaxes the dependency versions fix to minor version.

## Why ❔

The nightly-2023-08-21 is used by zksync-era repo so it makes sense to use the same version to make sure code in this repo compiles when used by zksync-era.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
