### PR TITLE
Prepare 0.1.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,17 +228,9 @@ name = "cudart"
 version = "0.1.0"
 dependencies = [
  "bitflags",
- "cudart-sys",
+ "era_cudart_sys",
  "paste",
  "serial_test",
-]
-
-[[package]]
-name = "cudart-sys"
-version = "0.1.0"
-dependencies = [
- "bindgen",
- "serde_json",
 ]
 
 [[package]]
@@ -246,6 +238,14 @@ name = "either"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
+name = "era_cudart_sys"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
+ "serde_json",
+]
 
 [[package]]
 name = "errno"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ name = "criterion-cuda"
 version = "0.1.0"
 dependencies = [
  "criterion",
- "cudart",
+ "era_cudart",
 ]
 
 [[package]]
@@ -224,7 +224,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "cudart"
+name = "either"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
+name = "era_cudart"
 version = "0.1.0"
 dependencies = [
  "bitflags",
@@ -232,12 +238,6 @@ dependencies = [
  "paste",
  "serial_test",
 ]
-
-[[package]]
-name = "either"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "era_cudart_sys"

--- a/criterion-cuda/Cargo.toml
+++ b/criterion-cuda/Cargo.toml
@@ -6,4 +6,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 criterion = "0.5"
-cudart = { path = "../cudart" }
+cudart = { package = "era_cudart", path = "../cudart" }

--- a/cudart-sys/Cargo.toml
+++ b/cudart-sys/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
-name = "cudart-sys"
+name = "era_cudart_sys"
 version = "0.1.0"
 edition = "2021"
+authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
+homepage = "https://zksync.io/"
+repository = "https://github.com/matter-labs/era-cuda"
 license = "MIT OR Apache-2.0"
+keywords = ["blockchain", "zksync"]
+categories = ["cryptography"]
+description = "Raw CUDA bindings for ZKsync"
 
 [build-dependencies]
 bindgen = "0.69"

--- a/cudart-sys/build.rs
+++ b/cudart-sys/build.rs
@@ -1,5 +1,5 @@
-use std::fs;
 use std::path::PathBuf;
+use std::{env, fs};
 
 use bindgen::callbacks::{EnumVariantValue, ParseCallbacks};
 
@@ -257,9 +257,7 @@ fn main() {
         .generate()
         .expect("Unable to generate bindings");
 
-    fs::write(
-        PathBuf::from("src").join("bindings.rs"),
-        bindings.to_string(),
-    )
-    .expect("Couldn't write bindings!");
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    fs::write(out_path.join("bindings.rs"), bindings.to_string())
+        .expect("Couldn't write bindings!");
 }

--- a/cudart-sys/src/lib.rs
+++ b/cudart-sys/src/lib.rs
@@ -10,7 +10,7 @@ use std::ffi::CStr;
 use std::fmt::{Debug, Display, Formatter};
 use std::mem::MaybeUninit;
 
-include!("bindings.rs");
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 impl CudaError {
     pub fn eprint_error(self) {

--- a/cudart/Cargo.toml
+++ b/cudart/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cudart"
+name = "era_cudart"
 version = "0.1.0"
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]

--- a/cudart/Cargo.toml
+++ b/cudart/Cargo.toml
@@ -2,10 +2,16 @@
 name = "cudart"
 version = "0.1.0"
 edition = "2021"
+authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
+homepage = "https://zksync.io/"
+repository = "https://github.com/matter-labs/era-cuda"
 license = "MIT OR Apache-2.0"
+keywords = ["blockchain", "zksync"]
+categories = ["cryptography"]
+description = "CUDA bindings for ZKsync"
 
 [dependencies]
-cudart-sys = { path = "../cudart-sys" }
+cudart-sys = { package = "era_cudart_sys", version = "=0.1.0", path = "../cudart-sys" }
 bitflags = "2.5"
 paste = "1.0"
 


### PR DESCRIPTION
# What ❔

Prepares 0.1.0 release (already on crates.io)

⚠️ Changes the build script for cudart to use [`OUT_DIR`](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts), since it's an idiomatic approach and breaking it [may have unexpected results](https://github.com/rust-lang/cargo/issues/5073).

## Why ❔

Releasing on crates.io

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo check` for any errors or warnings.
